### PR TITLE
Implement TimeFormatGuess except for GuessPattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ java {
 javadoc {
     title = "${project.name} v${project.version}"
 
+    // "timeformat" classes are intentionally undocumented while some are public classes to be accessed from org.embulk.util.guess.
+    exclude "org/embulk/util/guess/timeformat/*.java"
+
     options {
         locale = "en_US"
         encoding = "UTF-8"

--- a/src/main/java/org/embulk/util/guess/TimeFormatGuess.java
+++ b/src/main/java/org/embulk/util/guess/TimeFormatGuess.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.embulk.util.guess.timeformat.ExpectedPatterns;
+import org.embulk.util.guess.timeformat.TimeFormatMatch;
+import org.embulk.util.guess.timeformat.TimeFormatPattern;
+
+/**
+ * Guesses a time format from objects.
+ *
+ * <p>It reimplements {@code TimeFormatGuess} in {@code /embulk/guess/time_format_guess.rb}.
+ *
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess/time_format_guess.rb">time_format_guess.rb</a>
+ */
+public final class TimeFormatGuess {
+    private TimeFormatGuess() {
+    }
+
+    public static TimeFormatGuess of() {
+        return new TimeFormatGuess();
+    }
+
+    /**
+     * Guesses a time format from objects.
+     *
+     * @param texts  a sequence of strings used to guess
+     * @return the timestamp format string guessed
+     */
+    public String guess(final Iterable<Object> texts) {
+        final ArrayList<TimeFormatMatch> matches = new ArrayList<>();
+        for (final Object textObject : texts) {
+            final String text = textObject.toString();
+            if (text.isEmpty()) {
+                continue;
+            }
+            for (final TimeFormatPattern pattern : ExpectedPatterns.PATTERNS) {
+                final TimeFormatMatch match = pattern.match(text);
+                if (match != null) {
+                    matches.add(match);
+                }
+            }
+        }
+        if (matches.isEmpty()) {
+            return null;
+        } else if (matches.size() == 1) {
+            return matches.get(0).getFormat();
+        }
+
+        return mergeMostFrequentMatches(matches).getFormat();
+    }
+
+    /**
+     * Merges all the most frequent {@code TimeFormatMatch}s whose "identifier"s are the same.
+     *
+     * <pre>{@code  # Original code in Ruby.
+     *  match_groups = matches.group_by {|match| match.mergeable_group }.values
+     *  best_match_group = match_groups.sort_by {|group| group.size }.last
+     *  best_match = best_match_group.shift
+     *  best_match_group.each {|m| best_match.merge!(m) }
+     *  return best_match.format}</pre>
+     */
+    static TimeFormatMatch mergeMostFrequentMatches(final List<TimeFormatMatch> matches) {
+        final Collection<List<TimeFormatMatch>> matchGroups =
+                matches.stream().collect(Collectors.groupingBy(TimeFormatMatch::getIdentifier)).values();
+        final Optional<List<TimeFormatMatch>> bestMatchGroup = matchGroups.stream().max(Comparator.comparing(List::size));
+        if (!bestMatchGroup.isPresent() || bestMatchGroup.get().isEmpty()) {
+            return null;
+        }
+
+        final TimeFormatMatch bestMatch = bestMatchGroup.get().get(0);
+        for (final TimeFormatMatch match : bestMatchGroup.get()) {
+            bestMatch.mergeFrom(match);
+        }
+        return bestMatch;
+    }
+}

--- a/src/main/java/org/embulk/util/guess/timeformat/ExpectedPatterns.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/ExpectedPatterns.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+import static org.embulk.util.guess.timeformat.Parts.MONTH_NAME_SHORT;
+import static org.embulk.util.guess.timeformat.Parts.WEEKDAY_NAME_SHORT;
+import static org.embulk.util.guess.timeformat.Parts.ZONE_OFF;
+
+import java.util.regex.Pattern;
+
+/**
+ * Declares expected patterns in {@code TimeFormatGuess}.
+ *
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess/time_format_guess.rb#L384-L389">time_format_guess.rb</a>
+ */
+public final class ExpectedPatterns {
+    private ExpectedPatterns() {
+        // No instantiation.
+    }
+
+    /**
+     * <pre>{@code APACHE_CLF = /^\d\d\/#{MONTH_NAME_SHORT}\/\d\d\d\d:\d\d:\d\d:\d\d #{ZONE_OFF}?$/}</pre>
+     */
+    private static final Pattern APACHE_CLF = Pattern.compile(String.format(
+            "^\\d\\d\\/%s\\/\\d\\d\\d\\d:\\d\\d:\\d\\d:\\d\\d %s?$", MONTH_NAME_SHORT, ZONE_OFF));
+
+    /**
+     * <pre>{@code ANSI_C_ASCTIME = /^#{WEEKDAY_NAME_SHORT} #{MONTH_NAME_SHORT} \d\d? \d\d:\d\d:\d\d \d\d\d\d$/}</pre>
+     */
+    private static final Pattern ANSI_C_ASCTIME = Pattern.compile(String.format(
+            "^%s %s \\d\\d? \\d\\d:\\d\\d:\\d\\d \\d\\d\\d\\d$", WEEKDAY_NAME_SHORT, MONTH_NAME_SHORT));
+
+    public static final TimeFormatPattern[] PATTERNS = {
+        // TODO: Implement GuessPattern().
+
+        new Rfc2822Pattern(),
+
+        /**
+         * <pre>{@code RegexpPattern.new(StandardPatterns::APACHE_CLF, "%d/%b/%Y:%H:%M:%S %z")}</pre>
+         */
+        new RegexpPattern(APACHE_CLF, "%d/%b/%Y:%H:%M:%S %z"),
+
+        /**
+         * <pre>{@code RegexpPattern.new(StandardPatterns::ANSI_C_ASCTIME, "%a %b %e %H:%M:%S %Y")}</pre>
+         */
+        new RegexpPattern(ANSI_C_ASCTIME, "%a %b %e %H:%M:%S %Y"),
+    };
+}

--- a/src/main/java/org/embulk/util/guess/timeformat/Parts.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/Parts.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+/**
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess/time_format_guess.rb#L3-L22">time_format_guess.rb</a>
+ */
+class Parts {
+    private Parts() {
+        // No instantiation.
+    }
+
+    /**
+     * <pre>{@code MONTH_NAME_SHORT = /Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/}</pre>
+     */
+    static final String MONTH_NAME_SHORT =
+            "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)";
+
+    /**
+     * <pre>{@code MONTH_NAME_FULL = /January|February|March|April|May|June|July|August|September|October|November|December/}</pre>
+     */
+    static final String MONTH_NAME_FULL =
+            "(January|February|March|April|May|June|July|August|September|October|November|December)";
+
+    /**
+     * <pre>{@code WEEKDAY_NAME_SHORT = /Sun|Mon|Tue|Wed|Thu|Fri|Sat/}</pre>
+     */
+    static final String WEEKDAY_NAME_SHORT =
+            "(Sun|Mon|Tue|Wed|Thu|Fri|Sat)";
+
+    /**
+     * <pre>{@code WEEKDAY_NAME_FULL = /Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday/}</pre>
+     */
+    static final String WEEKDAY_NAME_FULL =
+            "(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)";
+
+    /**
+     * <pre>{@code ZONE_OFF = /(?:Z|[\-\+]\d\d(?::?\d\d)?)/}</pre>
+     */
+    static final String ZONE_OFF = "(?:Z|[\\-\\+]\\d\\d(?::?\\d\\d)?)";
+
+    /**
+     * <pre>{@code ZONE_ABB = /[A-Z]{1,3}/}</pre>
+     */
+    static final String ZONE_ABB = "([A-Z]{1,3})";
+}

--- a/src/main/java/org/embulk/util/guess/timeformat/RegexpPattern.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/RegexpPattern.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+import java.util.regex.Pattern;
+
+/**
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess/time_format_guess.rb#L362-L375">time_format_guess.rb</a>
+ */
+final class RegexpPattern implements TimeFormatPattern {
+    RegexpPattern(final Pattern regexp, final String formatToBe) {
+        this.regexp = regexp;
+        this.formatToBe = formatToBe;
+    }
+
+    @Override
+    public TimeFormatMatch match(final String text) {
+        if (this.regexp.matcher(text).matches()) {
+            return new SimpleMatch(this.formatToBe);
+        }
+        return null;
+    }
+
+    private final Pattern regexp;
+    private final String formatToBe;
+}

--- a/src/main/java/org/embulk/util/guess/timeformat/Rfc2822Pattern.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/Rfc2822Pattern.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+import static org.embulk.util.guess.timeformat.Parts.MONTH_NAME_SHORT;
+import static org.embulk.util.guess.timeformat.Parts.WEEKDAY_NAME_SHORT;
+import static org.embulk.util.guess.timeformat.Parts.ZONE_ABB;
+import static org.embulk.util.guess.timeformat.Parts.ZONE_OFF;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess/time_format_guess.rb#L331-L360">time_format_guess.rb</a>
+ */
+final class Rfc2822Pattern implements TimeFormatPattern {
+    Rfc2822Pattern() {}
+
+    @Override
+    public TimeFormatMatch match(final String text) {
+        final Matcher matcher = REGEX.matcher(text);
+
+        if (matcher.matches()) {
+            final StringBuilder format = new StringBuilder();
+            if (matcher.group("weekday") != null && !matcher.group("weekday").isEmpty()) {
+                format.append("%a, ");
+            }
+            format.append("%d %b %Y");
+            if (matcher.group("time") != null && !matcher.group("time").isEmpty()) {
+                format.append(" %H:%M");
+            }
+            if (matcher.group("second") != null && !matcher.group("second").isEmpty()) {
+                format.append(":%S");
+            }
+            if (matcher.group("zoneOff") != null && !matcher.group("zoneOff").isEmpty()) {
+                if (matcher.group("zoneOff") != null && matcher.group("zoneOff").contains(":")) {
+                    format.append(" %:z");
+                } else {
+                    format.append(" %z");
+                }
+            } else if (matcher.group("zoneAbb") != null && !matcher.group("zoneAbb").isEmpty()) {
+                // don't use %Z: https://github.com/jruby/jruby/issues/3702
+                if (matcher.group("zoneAbb") != null && !matcher.group("zoneAbb").isEmpty()) {
+                    format.append(" %z");
+                }
+            }
+            return new SimpleMatch(format.toString());
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    /**
+     * The regular expression of the RFC 2822 pattern.
+     *
+     * <pre>{@code  # Original code in Ruby.
+     *  @regexp = /^(?<weekday>#{WEEKDAY_NAME_SHORT}, )?\d\d #{MONTH_NAME_SHORT} \d\d\d\d(?<time> \d\d:\d\d(?<second>:\d\d)? (?:(?<zone_off>#{ZONE_OFF})|(?<zone_abb>#{ZONE_ABB})))?$/}</pre>
+     */
+    private static final Pattern REGEX = Pattern.compile(String.format(
+            "^(?<weekday>%s, )?\\d\\d %s \\d\\d\\d\\d(?<time> \\d\\d:\\d\\d(?<second>:\\d\\d)? (?:(?<zoneOff>%s)|(?<zoneAbb>%s)))?$",
+            WEEKDAY_NAME_SHORT, MONTH_NAME_SHORT, ZONE_OFF, ZONE_ABB));
+}

--- a/src/main/java/org/embulk/util/guess/timeformat/Rfc2822Pattern.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/Rfc2822Pattern.java
@@ -47,16 +47,14 @@ final class Rfc2822Pattern implements TimeFormatPattern {
                 format.append(":%S");
             }
             if (matcher.group("zoneOff") != null && !matcher.group("zoneOff").isEmpty()) {
-                if (matcher.group("zoneOff") != null && matcher.group("zoneOff").contains(":")) {
+                if (matcher.group("zoneOff").contains(":")) {
                     format.append(" %:z");
                 } else {
                     format.append(" %z");
                 }
             } else if (matcher.group("zoneAbb") != null && !matcher.group("zoneAbb").isEmpty()) {
                 // don't use %Z: https://github.com/jruby/jruby/issues/3702
-                if (matcher.group("zoneAbb") != null && !matcher.group("zoneAbb").isEmpty()) {
-                    format.append(" %z");
-                }
+                format.append(" %z");
             }
             return new SimpleMatch(format.toString());
         }

--- a/src/main/java/org/embulk/util/guess/timeformat/SimpleMatch.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/SimpleMatch.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+final class SimpleMatch implements TimeFormatMatch {
+    SimpleMatch(final String format) {
+        this.format = format;
+    }
+
+    @Override
+    public String getFormat() {
+        return this.format;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return this.format;
+    }
+
+    @Override
+    public void mergeFrom(final TimeFormatMatch anotherInGroup) {
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SimpleMatch[%s]", this.format);
+    }
+
+    private final String format;
+}

--- a/src/main/java/org/embulk/util/guess/timeformat/TimeFormatMatch.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/TimeFormatMatch.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+public interface TimeFormatMatch {
+    /**
+     * Returns the format matched.
+     */
+    String getFormat();
+
+    /**
+     * Returns an identifier string of this match.
+     *
+     * <p>If the identifier is the same with another, they are considered to be "mergeable".
+     */
+    String getIdentifier();
+
+    /**
+     * Merges another mergeable match into this match.
+     */
+    void mergeFrom(TimeFormatMatch anotherInGroup);
+}

--- a/src/main/java/org/embulk/util/guess/timeformat/TimeFormatPattern.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/TimeFormatPattern.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+public interface TimeFormatPattern {
+    TimeFormatMatch match(String text);
+}

--- a/src/test/java/org/embulk/util/guess/TestTimeFormatGuess.java
+++ b/src/test/java/org/embulk/util/guess/TestTimeFormatGuess.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import org.embulk.util.guess.timeformat.TimeFormatMatch;
+import org.junit.jupiter.api.Test;
+
+public class TestTimeFormatGuess {
+    @Test
+    public void testMultiple() {
+        assertTimeFormat(
+                "%a, %d %b %Y %H:%M %z",
+                "Fri, 20 Feb 2015 22:02 +00",
+                "Fri, 20 Feb 2015 22:03 +00:00",
+                "Fri, 20 Feb 2015 22:04 Z",
+                "Fri, 20 Feb 2015 22:05 +0000");
+        assertTimeFormat(
+                "%a, %d %b %Y %H:%M %:z",
+                "Fri, 20 Feb 2016 22:00 Z",
+                "Fri, 20 Feb 2016 22:01 -05:00",
+                "Fri, 20 Feb 2016 22:02 +01:00",
+                "Fri, 20 Feb 2016 22:03 +01:00",
+                "Fri, 20 Feb 2016 22:03:03 +00:00",
+                "Fri, 20 Feb 2016 22:04:04 +03:00",
+                "Fri, 20 Feb 2016 22:04 +12:00",
+                "Fri, 20 Feb 2016 22:05 +02:00",
+                "Fri, 20 Feb 2016 22:06 +10",
+                "Fri, 20 Feb 2016 22:06 Z",
+                "Fri, 20 Feb 2016 22:07 +1230");
+    }
+
+    @SuppressWarnings("checkstyle:ParenPad")
+    @Test
+    public void testFormatRfc2822() {
+        // This test is disabled because of https://github.com/jruby/jruby/issues/3702
+        // assertTimeFormat("%a, %d %b %Y %H:%M:%S %Z", "Fri, 20 Feb 2015 14:02:34 PST");
+        assertTimeFormat("%a, %d %b %Y %H:%M:%S %z", "Fri, 20 Feb 2015 22:02:34 UT");
+        assertTimeFormat("%a, %d %b %Y %H:%M:%S %z", "Fri, 20 Feb 2015 22:02:34 GMT");
+        assertTimeFormat(    "%d %b %Y %H:%M:%S %z",      "20 Feb 2015 22:02:34 GMT");
+        assertTimeFormat(    "%d %b %Y %H:%M %z",         "20 Feb 2015 22:02 GMT");
+        assertTimeFormat("%a, %d %b %Y %H:%M %z",    "Fri, 20 Feb 2015 22:02 GMT");
+        assertTimeFormat(    "%d %b %Y",                  "20 Feb 2015");
+        assertTimeFormat("%a, %d %b %Y",             "Fri, 20 Feb 2015");
+        assertTimeFormat("%a, %d %b %Y %H:%M %z",    "Fri, 20 Feb 2015 22:02 +0000");
+        assertTimeFormat("%a, %d %b %Y %H:%M %:z",   "Fri, 20 Feb 2015 22:02 +00:00");
+        assertTimeFormat("%a, %d %b %Y %H:%M %z",    "Fri, 20 Feb 2015 22:02 +00");
+    }
+
+    @Test
+    public void testFormatApacheClf() {
+        assertTimeFormat("%d/%b/%Y:%H:%M:%S %z", "07/Mar/2004:16:05:50 -0800");
+    }
+
+    @Test
+    public void testFormatAnsiCAsctime() {
+        assertTimeFormat("%a %b %e %H:%M:%S %Y", "Fri May 11 21:44:53 2001");
+    }
+
+    @Test
+    public void testMergeMostFrequentMatches() {
+        final TimeFormatMatch[] matches1 = {
+            new FakeMatch("foo"),
+            new FakeMatch("bar"),
+            new FakeMatch("bar"),
+            new FakeMatch("foo"),
+            new FakeMatch("foo"),
+            new FakeMatch("bar"),
+            new FakeMatch("foo"),
+        };
+        assertEquals("foo", TimeFormatGuess.mergeMostFrequentMatches(Arrays.asList(matches1)).getFormat());
+
+        final TimeFormatMatch[] matches2 = {
+            new FakeMatch("bar"),
+            new FakeMatch("foo"),
+            new FakeMatch("bar"),
+            new FakeMatch("bar"),
+            new FakeMatch("foo"),
+            new FakeMatch("bar"),
+            new FakeMatch("foo"),
+            new FakeMatch("foo"),
+            new FakeMatch("bar"),
+        };
+        assertEquals("bar", TimeFormatGuess.mergeMostFrequentMatches(Arrays.asList(matches2)).getFormat());
+    }
+
+    private static class FakeMatch implements TimeFormatMatch {
+        FakeMatch(final String format) {
+            this.format = format;
+        }
+
+        @Override
+        public String getFormat() {
+            return this.format;
+        }
+
+        @Override
+        public String getIdentifier() {
+            return this.format;
+        }
+
+        @Override
+        public void mergeFrom(final TimeFormatMatch anotherInGroup) {
+            return;
+        }
+
+        @Override
+        public String toString() {
+            return this.format + "(" + super.toString() + ")";
+        }
+
+        private final String format;
+    }
+
+    private static void assertTimeFormat(final String expected, final Object... examples) {
+        assertEquals(expected, TimeFormatGuess.of().guess(Arrays.asList(examples)));
+    }
+}

--- a/src/test/java/org/embulk/util/guess/timeformat/TestRfc2822Pattern.java
+++ b/src/test/java/org/embulk/util/guess/timeformat/TestRfc2822Pattern.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess.timeformat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TestRfc2822Pattern {
+    @SuppressWarnings("checkstyle:ParenPad")
+    @Test
+    public void test() {
+        // This test is disabled because of https://github.com/jruby/jruby/issues/3702
+        // assertRfc2822("%a, %d %b %Y %H:%M:%S %Z", "Fri, 20 Feb 2015 14:02:34 PST");
+        assertRfc2822("%a, %d %b %Y %H:%M:%S %z", "Fri, 20 Feb 2015 22:02:34 UT");
+        assertRfc2822("%a, %d %b %Y %H:%M:%S %z", "Fri, 20 Feb 2015 22:02:34 GMT");
+        assertRfc2822(    "%d %b %Y %H:%M:%S %z",      "20 Feb 2015 22:02:34 GMT");
+        assertRfc2822(    "%d %b %Y %H:%M %z",         "20 Feb 2015 22:02 GMT");
+        assertRfc2822("%a, %d %b %Y %H:%M %z",    "Fri, 20 Feb 2015 22:02 GMT");
+        assertRfc2822(    "%d %b %Y",                  "20 Feb 2015");
+        assertRfc2822("%a, %d %b %Y",             "Fri, 20 Feb 2015");
+        assertRfc2822("%a, %d %b %Y %H:%M %z",    "Fri, 20 Feb 2015 22:02 +0000");
+        assertRfc2822("%a, %d %b %Y %H:%M %:z",   "Fri, 20 Feb 2015 22:02 +00:00");
+        assertRfc2822("%a, %d %b %Y %H:%M %z",    "Fri, 20 Feb 2015 22:02 +00");
+    }
+
+    private static void assertRfc2822(final String expected, final String example) {
+        assertEquals(expected, new Rfc2822Pattern().match(example).getFormat());
+    }
+}


### PR DESCRIPTION
Reimplemented from:
https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess/time_format_guess.rb

except for `GuessPattern`, which is the most complicated guess.