### PR TITLE
Implement SchemaGuess

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     compileOnly "org.embulk:embulk-api:0.10.19"
     api "org.embulk:embulk-util-config:0.1.4"
     implementation "com.ibm.icu:icu4j:54.1.1"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.6.7"
 
     testImplementation "org.embulk:embulk-api:0.10.19"
     testImplementation "org.embulk:embulk-util-rubytime:0.3.2"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,6 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.ibm.icu:icu4j:54.1.1
 org.embulk:embulk-api:0.10.19
 org.embulk:embulk-util-config:0.1.4

--- a/src/main/java/org/embulk/util/guess/SchemaGuess.java
+++ b/src/main/java/org/embulk/util/guess/SchemaGuess.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.embulk.config.ConfigDiff;
+import org.embulk.util.config.ConfigMapperFactory;
+
+/**
+ * Guesses a schema from sample objects.
+ *
+ * <p>It reimplements {@code SchemaGuess} in {@code /embulk/guess/schema_guess.rb}.
+ *
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess/schema_guess.rb">schema_guess.rb</a>
+ */
+public final class SchemaGuess {
+    private SchemaGuess(final ConfigMapperFactory configMapperFactory, final TimeFormatGuess timeFormatGuess) {
+        this.configMapperFactory = configMapperFactory;
+        this.timeFormatGuess = timeFormatGuess;
+    }
+
+    public static SchemaGuess of(final ConfigMapperFactory configMapperFactory) {
+        return new SchemaGuess(configMapperFactory, TimeFormatGuess.of());
+    }
+
+    /**
+     * Guesses a schema from a list of sample records in {@link java.util.LinkedHashMap}s.
+     *
+     * <p>It returns a list of {@link org.embulk.config.ConfigDiff} in contrast to the original Ruby method returning
+     * {@link org.embulk.spi.Schema},
+     *
+     * <p>Note that it assumes {@link java.util.LinkedHashMap} because an order matters in schema.
+     *
+     * @param listOfMap  a list of {@link java.util.LinkedHashMap}s which represent a record for each
+     * @return a list of {@link org.embulk.config.ConfigDiff}s of the schema guessed
+     */
+    public List<ConfigDiff> fromLinkedHashMapRecords(final List<LinkedHashMap<String, Object>> listOfMap) {
+        if (listOfMap.isEmpty()) {
+            throw new RuntimeException("SchemaGuess cannot guess Schema from no records.");
+        }
+        final List<String> columnNames = Collections.unmodifiableList(new ArrayList<String>(listOfMap.get(0).keySet()));
+
+        final List<List<Object>> samples = new ArrayList<>();
+        for (final LinkedHashMap<String, Object> map : listOfMap) {
+            final ArrayList<Object> record = new ArrayList<>();
+            for (final String name : columnNames) {
+                record.add(map.get(name));
+            }
+            samples.add(Collections.unmodifiableList(record));
+        }
+        return this.fromListRecords(columnNames, Collections.unmodifiableList(samples));
+    }
+
+    /**
+     * Guesses a schema from a list of sample records in {@link java.util.LinkedHashMap}s.
+     *
+     * <p>It returns a list of {@link org.embulk.config.ConfigDiff} in contrast to the original Ruby method returning
+     * {@link org.embulk.spi.Schema},
+     *
+     * @param columnNames  a list of column names in order
+     * @param samples  a list of sample data
+     * @return a list of {@link org.embulk.config.ConfigDiff}s of the schema guessed
+     */
+    public List<ConfigDiff> fromListRecords(final List<String> columnNames, final List<List<Object>> samples) {
+        final List<GuessedType> columnTypes = typesFromListRecords(samples);
+        if (columnNames.size() != columnTypes.size()) {
+            throw new IllegalArgumentException("The number of column names are different from actual sample data.");
+        }
+
+        final List<ConfigDiff> columns = new ArrayList<>();
+
+        final int size = columnNames.size();
+        for (int i = 0; i < size; ++i) {
+            final GuessedType type = columnTypes.get(i);
+            final String name = columnNames.get(i);
+
+            final ConfigDiff column = this.configMapperFactory.newConfigDiff();
+            column.set("index", i);
+            column.set("name", name);
+            column.set("type", type.toString());
+            if (type.isTimestamp()) {
+                column.set("format", type.getFormatOrTimeValue());
+            }
+            columns.add(column);
+        }
+
+        return Collections.unmodifiableList(columns);
+    }
+
+    private static class GuessedType implements Comparable<GuessedType> {
+        private GuessedType(final String string, final String formatOrTimeValue) {
+            this.string = string;
+            this.formatOrTimeValue = formatOrTimeValue;
+        }
+
+        private GuessedType(final String string) {
+            this(string, null);
+        }
+
+        static GuessedType timestamp(final String formatOrTimeValue) {
+            return new GuessedType("timestamp", formatOrTimeValue);
+        }
+
+        boolean isTimestamp() {
+            return this.string.equals("timestamp");
+        }
+
+        String getFormatOrTimeValue() {
+            return this.formatOrTimeValue;
+        }
+
+        @Override
+        public boolean equals(final Object otherObject) {
+            if (!(otherObject instanceof GuessedType)) {
+                return false;
+            }
+            final GuessedType other = (GuessedType) otherObject;
+            return Objects.equals(this.string, other.string) && Objects.equals(this.formatOrTimeValue, other.formatOrTimeValue);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.string, this.formatOrTimeValue);
+        }
+
+        @Override
+        public int compareTo(final GuessedType other) {
+            if (this.formatOrTimeValue != null && other.formatOrTimeValue != null) {
+                return this.formatOrTimeValue.compareTo(other.formatOrTimeValue);
+            }
+            return this.string.compareTo(other.string);
+        }
+
+        @Override
+        public String toString() {
+            return this.string;
+        }
+
+        static final GuessedType BOOLEAN = new GuessedType("boolean");
+        static final GuessedType DOUBLE = new GuessedType("double");
+        static final GuessedType JSON = new GuessedType("json");
+        static final GuessedType LONG = new GuessedType("long");
+        static final GuessedType STRING = new GuessedType("string");
+
+        private final String string;
+        private final String formatOrTimeValue;
+    }
+
+    private List<GuessedType> typesFromListRecords(final List<List<Object>> samples) {
+        final int maxRecords = samples.stream().mapToInt(List::size).max().orElse(0);
+        if (maxRecords <= 0) {
+            return Collections.emptyList();
+        }
+        final ArrayList<ArrayList<GuessedType>> columnarTypes = new ArrayList<>(maxRecords);
+        for (int i = 0; i < maxRecords; ++i) {
+            columnarTypes.add(new ArrayList<>());
+        }
+
+        for (final List<Object> record : samples) {
+            for (int i = 0; i < record.size(); ++i) {
+                final Object value = record.get(i);
+                columnarTypes.get(i).add(this.guessType(value));
+            }
+        }
+
+        return columnarTypes.stream().map(types -> this.mergeTypes(types)).collect(Collectors.toList());
+    }
+
+    private GuessedType guessType(final Object value) {
+        if (value instanceof Map || value instanceof List) {
+            return GuessedType.JSON;
+        }
+        final String str = value.toString();
+
+        if (TRUE_STRINGS.contains(str) || FALSE_STRINGS.contains(str)) {
+            return GuessedType.BOOLEAN;
+        }
+
+        if (this.timeFormatGuess.guess(Arrays.asList(str)) != null) {
+            return GuessedType.timestamp(str);
+        }
+
+        try {
+            if (Integer.valueOf(str).toString().equals(str)) {
+                return GuessedType.LONG;
+            }
+        } catch (final RuntimeException ex) {
+            // Pass-through.
+        }
+
+        // Introduce a regular expression to make better suggestion to double type. It refers to Guava 21.0's regular
+        // expression in Doubles#fpPattern() but, there're difference as following:
+        // * It intentionaly rejects float values when they start with "0" like "001.0", "010.01". "0.1" is ok.
+        // * It doesn't support hexadecimal representation. It could be improved more later.
+        if (DOUBLE_PATTERN.matcher(str).matches()) {
+            return GuessedType.DOUBLE;
+        }
+
+        if (str.isEmpty()) {
+            return null;
+        }
+
+        try {
+            new ObjectMapper().readTree(str);
+            return GuessedType.JSON;
+        } catch (final Exception ex) {
+            // Pass-through.
+        }
+
+        return GuessedType.STRING;
+    }
+
+    private GuessedType mergeTypes(final List<GuessedType> types) {
+        final GuessedType t = Optional.ofNullable(types.stream().reduce(null, (final GuessedType merged, final GuessedType type) -> {
+            return mergeType(merged, type);
+        })).orElse(GuessedType.STRING);
+        if (t.isTimestamp()) {
+            final String format = this.timeFormatGuess.guess(
+                    types.stream()
+                            .map(type -> type.isTimestamp() ? type.getFormatOrTimeValue() : null)
+                            .filter(type -> type != null)
+                            .collect(Collectors.toList()));
+            return GuessedType.timestamp(format);
+        }
+        return t;
+    }
+
+    private static GuessedType mergeType(final GuessedType type1, final GuessedType type2) {
+        if (type1 == null) {
+            return type2;
+        } else if (type2 == null) {
+            return type1;
+        } else if (type1.equals(type2)) {
+            return type1;
+        } else {
+            return coalesceType(type1, type2);
+        }
+    }
+
+    private static GuessedType coalesceType(final GuessedType type1, final GuessedType type2) {
+        final GuessedType[] types = { type1, type2 };
+        Arrays.sort(types);
+
+        if (types[0] == GuessedType.DOUBLE && types[1] == GuessedType.LONG) {
+            return GuessedType.DOUBLE;
+        } else if (types[0] == GuessedType.BOOLEAN && types[1] == GuessedType.LONG) {
+            return GuessedType.LONG;
+        } else if (types[0] == GuessedType.LONG && types[1].isTimestamp()) {
+            return GuessedType.LONG;
+        }
+        return GuessedType.STRING;
+    }
+
+    private static final Pattern DOUBLE_PATTERN = Pattern.compile(
+            "/^[+-]?(NaN|Infinity|([1-9]\\d*|0)(\\.\\d+)([eE][+-]?\\d+)?[fFdD]?)$/");
+
+    // taken from CsvParserPlugin.TRUE_STRINGS
+    private static final String[] TRUE_STRINGS_ARRAY = {
+        "true", "True", "TRUE",
+        "yes", "Yes", "YES",
+        "t", "T", "y", "Y",
+        "on", "On", "ON",
+    };
+
+    private static final String[] FALSE_STRINGS_ARRAY = {
+        "false", "False", "FALSE",
+        "no", "No", "NO",
+        "f", "F", "n", "N",
+        "off", "Off", "OFF",
+    };
+
+    private static final Set<String> TRUE_STRINGS;
+    private static final Set<String> FALSE_STRINGS;
+
+    static {
+        TRUE_STRINGS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(TRUE_STRINGS_ARRAY)));
+        FALSE_STRINGS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(FALSE_STRINGS_ARRAY)));
+    }
+
+    private final ConfigMapperFactory configMapperFactory;
+
+    private final TimeFormatGuess timeFormatGuess;
+}

--- a/src/test/java/org/embulk/util/guess/TestSchemaGuess.java
+++ b/src/test/java/org/embulk/util/guess/TestSchemaGuess.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.embulk.config.ConfigDiff;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.guess.SchemaGuess;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestSchemaGuess {
+    @Test
+    public void testGuess() {
+        final LinkedHashMap<String, Object> record = new LinkedHashMap<>();
+        record.put("int", "1");
+        record.put("str", "a");
+        final ArrayList<LinkedHashMap<String, Object>> records = new ArrayList<>();
+        records.add(record);
+
+        final List<ConfigDiff> guessed = fromLinkedHashMap(records);
+        assertEquals(2, guessed.size());
+        assertEquals("0", guessed.get(0).get(String.class, "index"));
+        assertEquals(0, guessed.get(0).get(int.class, "index"));
+        assertEquals("int", guessed.get(0).get(String.class, "name"));
+        assertEquals("long", guessed.get(0).get(String.class, "type"));
+        assertFalse(guessed.get(0).has("format"));
+        assertEquals("1", guessed.get(1).get(String.class, "index"));
+        assertEquals(1, guessed.get(1).get(int.class, "index"));
+        assertEquals("str", guessed.get(1).get(String.class, "name"));
+        assertEquals("string", guessed.get(1).get(String.class, "type"));
+        assertFalse(guessed.get(1).has("format"));
+    }
+
+    @Test
+    public void testCoalesce1() {
+        final LinkedHashMap<String, Object> record1 = new LinkedHashMap<>();
+        record1.put("a", "20160101");
+        final LinkedHashMap<String, Object> record2 = new LinkedHashMap<>();
+        record2.put("a", "20160101");
+        final ArrayList<LinkedHashMap<String, Object>> records = new ArrayList<>();
+        records.add(record1);
+        records.add(record2);
+
+        final List<ConfigDiff> guessed = fromLinkedHashMap(records);
+        assertEquals(1, guessed.size());
+        assertEquals("0", guessed.get(0).get(String.class, "index"));
+        assertEquals(0, guessed.get(0).get(int.class, "index"));
+        assertEquals("a", guessed.get(0).get(String.class, "name"));
+        assertEquals("timestamp", guessed.get(0).get(String.class, "type"));
+        assertEquals("%Y%m%d", guessed.get(0).get(String.class, "format"));
+    }
+
+    @Test
+    public void testCoalesce2() {
+        final LinkedHashMap<String, Object> record1 = new LinkedHashMap<>();
+        record1.put("a", "20160101");
+        final LinkedHashMap<String, Object> record2 = new LinkedHashMap<>();
+        record2.put("a", "20160101");
+        final LinkedHashMap<String, Object> record3 = new LinkedHashMap<>();
+        record3.put("a", "12345678");
+        final ArrayList<LinkedHashMap<String, Object>> records = new ArrayList<>();
+        records.add(record1);
+        records.add(record2);
+        records.add(record3);
+
+        final List<ConfigDiff> guessed = fromLinkedHashMap(records);
+        assertEquals(1, guessed.size());
+        assertEquals("0", guessed.get(0).get(String.class, "index"));
+        assertEquals(0, guessed.get(0).get(int.class, "index"));
+        assertEquals("a", guessed.get(0).get(String.class, "name"));
+        assertEquals("long", guessed.get(0).get(String.class, "type"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "true",
+            "false",
+            "t",
+            "f",
+            "yes",
+            "no",
+            "y",
+            "n",
+            "on",
+            "off",
+    })
+    public void testBoolean(final String str) {
+        // If at least one of three kinds of boolean strings (i.e., downcase, upcase, capitalize) is
+        // mistakenly detected as "string," the guesser concludes the column type is "string."
+        final LinkedHashMap<String, Object> record1 = new LinkedHashMap<>();
+        record1.put("a", str.toLowerCase());
+        final LinkedHashMap<String, Object> record2 = new LinkedHashMap<>();
+        record2.put("a", str.toUpperCase());
+        final LinkedHashMap<String, Object> record3 = new LinkedHashMap<>();
+        record3.put("a", str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase());
+        final ArrayList<LinkedHashMap<String, Object>> records = new ArrayList<>();
+        records.add(record1);
+        records.add(record2);
+        records.add(record3);
+
+        final List<ConfigDiff> guessed = fromLinkedHashMap(records);
+        assertEquals(1, guessed.size());
+        assertEquals("0", guessed.get(0).get(String.class, "index"));
+        assertEquals(0, guessed.get(0).get(int.class, "index"));
+        assertEquals("a", guessed.get(0).get(String.class, "name"));
+        assertEquals("boolean", guessed.get(0).get(String.class, "type"));
+    }
+
+    private static List<ConfigDiff> fromLinkedHashMap(final List<LinkedHashMap<String, Object>> listOfMap) {
+        return SchemaGuess.of(CONFIG_MAPPER_FACTORY).fromLinkedHashMapRecords(listOfMap);
+    }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.withDefault();
+}


### PR DESCRIPTION
The last basic one to reimplement!

I'm thinking about how we deal with `TextGuessPlugin` and `LineGuessPlugin` extending `GuessPlugin`. They may be added in this library later.
* https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess_plugin.rb#L46-L127