### PR TITLE
Implement TextGuessHelper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.19"
     api "org.embulk:embulk-util-config:0.1.4"
+    api "org.embulk:embulk-util-file:0.1.1"
+    api "org.embulk:embulk-util-text:0.1.0"
     implementation "com.ibm.icu:icu4j:54.1.1"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -7,5 +7,7 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.ibm.icu:icu4j:54.1.1
 org.embulk:embulk-api:0.10.19
 org.embulk:embulk-util-config:0.1.4
+org.embulk:embulk-util-file:0.1.1
+org.embulk:embulk-util-text:0.1.0
 org.msgpack:msgpack-core:0.8.11
 org.slf4j:slf4j-api:1.7.12

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -8,3 +8,5 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.ibm.icu:icu4j:54.1.1
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.1.4
+org.embulk:embulk-util-file:0.1.1
+org.embulk:embulk-util-text:0.1.0

--- a/src/main/java/org/embulk/util/guess/GuessUtil.java
+++ b/src/main/java/org/embulk/util/guess/GuessUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import java.nio.charset.Charset;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.Buffer;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.text.LineDelimiter;
+import org.embulk.util.text.Newline;
+
+final class GuessUtil {
+    private GuessUtil() {
+        // No instantiation.
+    }
+
+    static Charset getCharset(final ConfigSource parserConfig, final ConfigMapperFactory configMapperFactory, final Buffer sample) {
+        final String charsetString;
+        if (parserConfig.has("charset")) {
+            charsetString = parserConfig.get(String.class, "charset", "utf-8");
+        } else {
+            charsetString = CharsetGuess.of(configMapperFactory)
+                .guess(sample)
+                .getNestedOrGetEmpty("parser")
+                .get(String.class, "charset", "utf-8");
+        }
+
+        return Charset.forName(charsetString);
+    }
+
+    static LineDelimiter getLineDelimiter(final ConfigSource parserConfig) {
+        final String lineDelimiterString = parserConfig.get(String.class, "line_delimiter_recognized", null);
+        if (lineDelimiterString == null) {
+            return null;
+        }
+        return LineDelimiter.valueOf(LineDelimiter.class, lineDelimiterString);
+    }
+
+    static Newline getNewline(final ConfigSource parserConfig) {
+        final String newlineString = parserConfig.get(String.class, "newline", "CRLF");
+        if (newlineString == null) {
+            throw new IllegalArgumentException(new NullPointerException("newline is unexpectedly null."));
+        }
+        return Newline.valueOf(Newline.class, newlineString);
+    }
+
+    static boolean endsWith(final Buffer buffer, final Newline target) {
+        switch (target) {
+            case CR:
+            case LF:
+                if (buffer.offset() + buffer.limit() - 1 >= 0) {
+                    final byte[] last = new byte[1];
+                    buffer.getBytes(buffer.limit() - 1, last, 0, 1);
+                    return ((char) last[0]) == target.getFirstCharCode();
+                }
+                return false;
+
+            case CRLF:
+                if (buffer.offset() + buffer.limit() - 2 >= 0) {
+                    final byte[] last = new byte[2];
+                    buffer.getBytes(buffer.limit() - 2, last, 0, 2);
+                    return ((char) last[0]) == target.getFirstCharCode() && ((char) last[1]) == target.getSecondCharCode();
+                }
+                return false;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/org/embulk/util/guess/TextGuessHelper.java
+++ b/src/main/java/org/embulk/util/guess/TextGuessHelper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.Buffer;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.file.ListFileInput;
+import org.embulk.util.text.LineDecoder;
+import org.embulk.util.text.LineDelimiter;
+import org.embulk.util.text.Newline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A helper to convert {@link org.embulk.spi.Buffer} to {@link java.lang.String} for guess.
+ *
+ * <p>It reimplements {@code TextGuessPlugin} in {@code /embulk/guess_plugin.rb}.
+ *
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess_plugin.rb">guess_plugin.rb</a>
+ */
+public final class TextGuessHelper {
+    private TextGuessHelper(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
+    public static TextGuessHelper of(final ConfigMapperFactory configMapperFactory) {
+        return new TextGuessHelper(configMapperFactory);
+    }
+
+    public String toText(final ConfigSource config, final Buffer sample) {
+        final ConfigSource parserConfig = config.getNestedOrGetEmpty("parser");
+
+        final Charset charset;
+        try {
+            charset = GuessUtil.getCharset(parserConfig, this.configMapperFactory, sample);
+        } catch (final IllegalArgumentException ex) {
+            logger.warn(ex.getMessage(), ex);
+            return null;
+        }
+
+        final LineDelimiter lineDelimiter;
+        try {
+            lineDelimiter = GuessUtil.getLineDelimiter(parserConfig);
+        } catch (final IllegalArgumentException ex) {
+            logger.warn(ex.getMessage(), ex);
+            return null;
+        }
+
+        final Newline newline;
+        try {
+            newline = GuessUtil.getNewline(parserConfig);
+        } catch (final IllegalArgumentException ex) {
+            logger.warn(ex.getMessage(), ex);
+            return null;
+        }
+
+        final ArrayList<Buffer> listBuffer = new ArrayList<>();
+        listBuffer.add(sample);
+        final ArrayList<ArrayList<Buffer>> listListBuffer = new ArrayList<>();
+        listListBuffer.add(listBuffer);
+        final LineDecoder decoder = LineDecoder.of(new ListFileInput(listListBuffer), charset, lineDelimiter);
+
+        final StringBuilder sampleText = new StringBuilder();
+
+        while (decoder.nextFile()) {  // TODO: Confirm decoder contains only one, and stop looping.
+            boolean first = true;
+            while (true) {
+                final String line = decoder.poll();
+                if (line == null) {
+                    break;
+                }
+
+                if (first) {
+                    first = false;
+                } else {
+                    sampleText.append(newline.getString());
+                }
+                sampleText.append(line);
+            }
+        }
+
+        return sampleText.toString();
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(TextGuessHelper.class);
+
+    private final ConfigMapperFactory configMapperFactory;
+}

--- a/src/test/java/org/embulk/util/guess/TestTextGuessHelper.java
+++ b/src/test/java/org/embulk/util/guess/TestTextGuessHelper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.embulk.config.ConfigSource;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.junit.jupiter.api.Test;
+
+public class TestTextGuessHelper {
+    @Test
+    public void testCharsetShiftJis() {
+        assertTextGuess("いろはにほへとちりぬるを", "いろはにほへとちりぬるを".getBytes(Charset.forName("Shift_JIS")));
+    }
+
+    @Test
+    public void testCharsetEucJp() {
+        assertTextGuess("わかよたれそつねらなむ", "わかよたれそつねらなむ".getBytes(Charset.forName("EUC-JP")));
+    }
+
+    @Test
+    public void testNewlineDefault() {
+        assertTextGuess("The quick brown fox\r\njumps over\r\nthe lazy dog.",
+                        "The quick brown fox\njumps over\nthe lazy dog.".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testNewlineCr() {
+        assertTextGuess("The quick brown fox\rjumps over\rthe lazy dog.",
+                        "The quick brown fox\njumps over\nthe lazy dog.".getBytes(StandardCharsets.UTF_8),
+                        "CR");
+    }
+
+    private static void assertTextGuess(final String expectedString, final byte[] sample, final String newline) {
+        final ConfigSource parserConfig = CONFIG_MAPPER_FACTORY.newConfigSource();
+        if (newline != null) {
+            parserConfig.set("newline", newline);
+        }
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource();
+        config.setNested("parser", parserConfig);
+
+        assertEquals(expectedString, TextGuessHelper.of(CONFIG_MAPPER_FACTORY).toText(config, new FakeBufferImpl(sample)));
+    }
+
+    private static void assertTextGuess(final String expectedString, final byte[] sample) {
+        assertTextGuess(expectedString, sample, null);
+    }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.withDefault();
+}


### PR DESCRIPTION
It is an alternative to `TextGuessPlugin`, which is included in `embulk-core` as an extended class of the standard `GuessPlugin`.
https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess_plugin.rb#L46-L84

Instead of extending `GuessPlugin` again, it is just providing a helper method to convert `Buffer` to `String`.