### PR TITLE
Implement LineGuessHelper

### DIFF
--- a/src/main/java/org/embulk/util/guess/LineGuessHelper.java
+++ b/src/main/java/org/embulk/util/guess/LineGuessHelper.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.embulk.config.ConfigSource;
+import org.embulk.spi.Buffer;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.file.ListFileInput;
+import org.embulk.util.text.LineDecoder;
+import org.embulk.util.text.LineDelimiter;
+import org.embulk.util.text.Newline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A helper to convert {@link org.embulk.spi.Buffer} to {@link java.lang.String} for guess.
+ *
+ * <p>It reimplements {@code LineGuessPlugin} in {@code /embulk/guess_plugin.rb}.
+ *
+ * @see <a href="https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess_plugin.rb">guess_plugin.rb</a>
+ */
+public final class LineGuessHelper {
+    private LineGuessHelper(final ConfigMapperFactory configMapperFactory) {
+        this.configMapperFactory = configMapperFactory;
+    }
+
+    public static LineGuessHelper of(final ConfigMapperFactory configMapperFactory) {
+        return new LineGuessHelper(configMapperFactory);
+    }
+
+    public final List<String> toLines(final ConfigSource config, final Buffer sample) {
+        final ConfigSource parserConfig = config.getNestedOrGetEmpty("parser");
+
+        final Charset charset;
+        try {
+            charset = GuessUtil.getCharset(parserConfig, this.configMapperFactory, sample);
+        } catch (final IllegalArgumentException ex) {
+            logger.warn(ex.getMessage(), ex);
+            return null;
+        }
+
+        final LineDelimiter lineDelimiter;
+        try {
+            lineDelimiter = GuessUtil.getLineDelimiter(parserConfig);
+        } catch (final IllegalArgumentException ex) {
+            logger.warn(ex.getMessage(), ex);
+            return null;
+        }
+
+        final Newline newline;
+        try {
+            newline = GuessUtil.getNewline(parserConfig);
+        } catch (final IllegalArgumentException ex) {
+            logger.warn(ex.getMessage(), ex);
+            return null;
+        }
+
+        final ArrayList<Buffer> listBuffer = new ArrayList<>();
+        listBuffer.add(sample);
+        final ArrayList<ArrayList<Buffer>> listListBuffer = new ArrayList<>();
+        listListBuffer.add(listBuffer);
+        final LineDecoder decoder = LineDecoder.of(new ListFileInput(listListBuffer), charset, lineDelimiter);
+
+        final boolean endsWithNewline = GuessUtil.endsWith(sample, newline);
+
+        final ArrayList<String> sampleLines = new ArrayList<>();
+        while (decoder.nextFile()) {  // TODO: Confirm decoder contains only one, and stop looping.
+            while (true) {
+                final String line = decoder.poll();
+                if (line == null) {
+                    break;
+                }
+                sampleLines.add(line);
+            }
+            if (!endsWithNewline && !sampleLines.isEmpty()) {
+                sampleLines.remove(sampleLines.size() - 1);  // last line is partial
+            }
+        }
+
+        return Collections.unmodifiableList(sampleLines);
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(LineGuessHelper.class);
+
+    private final ConfigMapperFactory configMapperFactory;
+}

--- a/src/test/java/org/embulk/util/guess/TestLineGuessHelper.java
+++ b/src/test/java/org/embulk/util/guess/TestLineGuessHelper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.guess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import org.embulk.config.ConfigSource;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.junit.jupiter.api.Test;
+
+public class TestLineGuessHelper {
+    @Test
+    public void testOneLine() {
+        final int size = 65536;
+
+        final byte[] longByteArray = new byte[size];
+        Arrays.fill(longByteArray, (byte) '*');
+        assertLineGuess(Arrays.asList(), longByteArray);
+
+        longByteArray[size - 1] = (byte) '\n';
+        assertLineGuess(Arrays.asList(), longByteArray);
+        assertLineGuess(Arrays.asList(repeatedString('*', size - 1)), longByteArray, "LF");
+
+        longByteArray[size - 2] = (byte) '\r';
+        longByteArray[size - 1] = (byte) '\n';
+        assertLineGuess(Arrays.asList(repeatedString('*', size - 2)), longByteArray);
+        assertLineGuess(Arrays.asList(repeatedString('*', size - 2)), longByteArray, "LF");
+    }
+
+    @Test
+    public void testSimpleMultilines() {
+        assertLineGuess(Arrays.asList("abc", "def"), "abc\r\ndef\r\nghi".getBytes(StandardCharsets.UTF_8));
+        assertLineGuess(Arrays.asList("abc", "def", "ghi"), "abc\r\ndef\r\nghi\r\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void assertLineGuess(final List<String> expectedStrings, final byte[] sample, final String newline) {
+        final ConfigSource parserConfig = CONFIG_MAPPER_FACTORY.newConfigSource();
+        if (newline != null) {
+            parserConfig.set("newline", newline);
+        }
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource();
+        config.setNested("parser", parserConfig);
+
+        assertEquals(expectedStrings,
+                     LineGuessHelper.of(CONFIG_MAPPER_FACTORY).toLines(config, new FakeBufferImpl(sample)));
+    }
+
+    private static void assertLineGuess(final List<String> expectedStrings, final byte[] sample) {
+        assertLineGuess(expectedStrings, sample, null);
+    }
+
+    private static String repeatedString(final char ch, final int times) {
+        final StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < times; i++) {
+            builder.append(ch);
+        }
+        return builder.toString();
+    }
+
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.withDefault();
+}


### PR DESCRIPTION
Similar to #6, an alternative to `LineGuessPlugin`, which is included in `embulk-core` as an extended class of the standard `GuessPlugin`.
https://github.com/embulk/embulk/blob/v0.10.19/embulk-core/src/main/ruby/embulk/guess_plugin.rb#L86-L127

Instead of extending `GuessPlugin` again, it is just providing a helper method to convert `Buffer` to `List<String>`.