### PR TITLE
Guess a type of a null value as null

### DIFF
--- a/src/main/java/org/embulk/util/guess/SchemaGuess.java
+++ b/src/main/java/org/embulk/util/guess/SchemaGuess.java
@@ -193,6 +193,10 @@ public final class SchemaGuess {
     }
 
     private GuessedType guessType(final Object value) {
+        if (value == null) {
+            return null;
+        }
+
         if (value instanceof Map || value instanceof List) {
             return GuessedType.JSON;
         }


### PR DESCRIPTION
Fixing a bug which is found through reimplementing `embulk-util-csv` in https://github.com/embulk/embulk/pull/1377.

If a `null` value is passed, it was throwing an exception. The `guessType` method should have returned `null` for `null`.