### PR TITLE
Fix the regex pattern for DOUBLE

### DIFF
--- a/src/main/java/org/embulk/util/guess/SchemaGuess.java
+++ b/src/main/java/org/embulk/util/guess/SchemaGuess.java
@@ -282,7 +282,7 @@ public final class SchemaGuess {
     }
 
     private static final Pattern DOUBLE_PATTERN = Pattern.compile(
-            "/^[+-]?(NaN|Infinity|([1-9]\\d*|0)(\\.\\d+)([eE][+-]?\\d+)?[fFdD]?)$/");
+            "^[+-]?(NaN|Infinity|([1-9]\\d*|0)(\\.\\d+)([eE][+-]?\\d+)?[fFdD]?)$");
 
     // taken from CsvParserPlugin.TRUE_STRINGS
     private static final String[] TRUE_STRINGS_ARRAY = {


### PR DESCRIPTION
Fixing a bug which is found through reimplementing `embulk-util-csv` in https://github.com/embulk/embulk/pull/1377.

The regex pattern for `DOUBLE` was totally wrong. It included `/` in Ruby's regexp literal `/.../`...