### PR TITLE
Merge two guess results of TIMESTAMP type still into TIMESTAMP even if their timestamp formats are different

### DIFF
--- a/src/main/java/org/embulk/util/guess/SchemaGuess.java
+++ b/src/main/java/org/embulk/util/guess/SchemaGuess.java
@@ -135,6 +135,30 @@ public final class SchemaGuess {
             return this.formatOrTimeValue;
         }
 
+        /**
+         * Returns {@code true} if just its type is the same with another object's.
+         *
+         * <p>Note that it does not take care of {@code formatOrTimeValue}. It returns {@code true} if
+         * both are {@code "timestamp"}, even if their {@code formatOrTimeValue}s are different.
+         *
+         * <p>It is expected to be called only from {@code mergeType} which should merge {@code "timestamp"}
+         * and {@code "timestamp"} into {@code "timestamp"}, even if their {@code formatOrTimeValue}s are
+         * different. Those {@code formatOrTimeValue}s are considered in {@code mergeTypes} later.
+         */
+        boolean typeEquals(final Object otherObject) {
+            if (!(otherObject instanceof GuessedType)) {
+                return false;
+            }
+            final GuessedType other = (GuessedType) otherObject;
+            return Objects.equals(this.string, other.string);
+        }
+
+        /**
+         * Returns {@code true} if its type and {@code formatOrTimeValue} are the same with another object's.
+         *
+         * <p>Note that it takes care of {@code formatOrTimeValue}. This equality is used out of {@code SchemaGuess},
+         * in {@code CSVGuessPlugin} to compare lists of {@code GuessedType}s.
+         */
         @Override
         public boolean equals(final Object otherObject) {
             if (!(otherObject instanceof GuessedType)) {
@@ -260,7 +284,7 @@ public final class SchemaGuess {
             return type2;
         } else if (type2 == null) {
             return type1;
-        } else if (type1.equals(type2)) {
+        } else if (type1.typeEquals(type2)) {
             return type1;
         } else {
             return coalesceType(type1, type2);

--- a/src/test/java/org/embulk/util/guess/TestSchemaGuess.java
+++ b/src/test/java/org/embulk/util/guess/TestSchemaGuess.java
@@ -92,6 +92,25 @@ public class TestSchemaGuess {
         assertEquals("long", guessed.get(0).get(String.class, "type"));
     }
 
+    @Test
+    public void testCoalesce3TimestampFormat() {
+        final LinkedHashMap<String, Object> record1 = new LinkedHashMap<>();
+        record1.put("a", "2016-01-01T12:34:56");
+        final LinkedHashMap<String, Object> record2 = new LinkedHashMap<>();
+        record2.put("a", "2016/01/01 12:34:56");
+        final ArrayList<LinkedHashMap<String, Object>> records = new ArrayList<>();
+        records.add(record1);
+        records.add(record2);
+
+        final List<ConfigDiff> guessed = fromLinkedHashMap(records);
+        assertEquals(1, guessed.size());
+        assertEquals("0", guessed.get(0).get(String.class, "index"));
+        assertEquals(0, guessed.get(0).get(int.class, "index"));
+        assertEquals("a", guessed.get(0).get(String.class, "name"));
+        assertEquals("timestamp", guessed.get(0).get(String.class, "type"));
+        // Not testing timestamp format.
+    }
+
     @ParameterizedTest
     @CsvSource({
             "true",


### PR DESCRIPTION
Fixing a bug which is found through reimplementing `embulk-util-csv` in https://github.com/embulk/embulk/pull/1377.

When two values were guessed as `TIMESTAMP`, but if their timestamp formats were different, they were merged into `STRING`. They should still be `TIMESTAMP` even if their guessed formats are different. (Different timestamp formats are merged in later steps.)