### PR TITLE
CRITICAL vulnerability: bump jackson from 2.6.7 to 2.9.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ dependencies {
     api "org.embulk:embulk-util-file:0.1.1"
     api "org.embulk:embulk-util-text:0.1.0"
     implementation "com.ibm.icu:icu4j:54.1.1"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.9.10"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.9.10"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.9.10"
 
     testImplementation "org.embulk:embulk-api:0.10.19"
     testImplementation "org.embulk:embulk-util-rubytime:0.3.2"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7
-com.fasterxml.jackson.core:jackson-core:2.6.7
-com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.core:jackson-annotations:2.9.10
+com.fasterxml.jackson.core:jackson-core:2.9.10
+com.fasterxml.jackson.core:jackson-databind:2.9.10
 com.ibm.icu:icu4j:54.1.1
 org.embulk:embulk-api:0.10.19
 org.embulk:embulk-util-config:0.1.4

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7
-com.fasterxml.jackson.core:jackson-core:2.6.7
-com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.core:jackson-annotations:2.9.10
+com.fasterxml.jackson.core:jackson-core:2.9.10
+com.fasterxml.jackson.core:jackson-databind:2.9.10
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.ibm.icu:icu4j:54.1.1
 javax.validation:validation-api:1.1.0.Final


### PR DESCRIPTION
# Vulnerability Information

Bumps [jackson-databind](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.6.7) from 2.6.7 to 2.9.10.

Listed dependency **com.fasterxml.jackson.core:jackson-databind** contains vulnerable methods which are called from this project. This vulnerability appears to affect *jackson-databind* package versions lower than 2.9.9.2 (excluding). The vulnerability has been fixed in version 2.9.9.2, as can be seen from the linked CVE or package [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9) -
the micro-patch of 2.9.9.2 refers to the fix of this vulnerability.

The other jackson packages were also bumped in order to keep the version compatibility with the updated jackson-databind 2.9.10 package.

| <center>Property</center> | <center>Value</center> |
|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
| <center> Linked CVE </center> | CVE-2019-14379                                                                                |
| <center> Number of affected methods </center> | 1                                                                                                                |
| <center>Severity</center> | **CRITICAL**                                                                                                                                     |
| <center>Current version</center> | 2.6.7                                                                                                                                        |
| <center>Updated version</center> | 2.9.10                                                                                                                                  |
| <center>Backwards Compatibility</center> | True                                                                                                                         | 


# Vulnerable method calls

| Methods in this repository                                                    | Used package methods                                           | Origin vulnerable method                                          |
|----------|---------------------------------------|------------------------------------------------------------------------|
| [org.embulk.util.guess/SchemaGuess.guessType(final Object value)][1] | com.fasterxml.jackson.databind/ObjectMapper.readTree(String content) | com.fasterxml.jackson.databind.deser.std/<br>EnumSetDeserializer(JavaType enumType, JsonDeserializer<?> deser) |
  | [org.embulk.util.guess/SchemaGuess.guessType(final Object value)][1] | com.fasterxml.jackson.databind/ObjectMapper.readTree(String content) | com.fasterxml.jackson.databind.deser/BasicDeserializerFactory.createMapDeserializer(DeserializationContext ctxt, MapType type, BeanDescription beanDesc) |

[1]: https://github.com/embulk/embulk-util-guess/blob/132357e9fe7c98a95affe96765f90098895da406/src/main/java/org/embulk/util/guess/SchemaGuess.java#L219

### What do the columns represent?
The 1st column in the table indicates the method in this repository that was found to be affected by vulnerable methods from the *jackson-databind* package.

The 2nd column indicates the *jackson-databind* method that was directly called from this repository.

The 3rd column indicates the origin vulnerable method in the *jackson-databind* package. According to our dataset, this is one of the methods that produces the **CVE-2019-14379** vulnerability. This method was found to be internally chain-called in the *jackson-databind* package by the method listed in column 2.


### How were the results generated?
This vulnerability was analyzed specifically for usage in this project using the [FASTEN Project](https://www.fasten-project.eu/view/Main/). Statical method-level analysis was used to check for usage of vulnerable methods in the project.

Method calls between your project and *jackson-databind* have been mapped using a directed graph. From this graph, it could be then be seen whether any vulnerable *jackson-databind* methods are being called from within your project.

# Research Scope

We are a [team](https://github.com/orgs/TU-Delft-Research-Group-2021/people) of 3 BSc Computer Science students at the TU Delft. Our goal is to conduct research on how developers react to method-level vulnerability information that affects their projects. We would highly appreciate if you could help us with our research and please tick statements which apply to you below.

### First impression checklist
- [ ] I have read this pull request description.
- [ ] I was aware of this dependency vulnerability affecting my project before being informed by this Pull Request.
- [ ] I was convinced by the provided method information that this vulnerability indeed affects my project.
- [ ] After seeing the provided method-level information, I plan on fixing the vulnerability.

### After fixing vulnerability checklist
- [ ] I found that the provided method information has made my process of dealing with the vulnerable dependency easier.
- [ ] I have given priority to the task of fixing the vulnerability over other project tasks that are yet to be completed.
- [ ] I would like to receive this kind of method information in future vulnerable dependency Pull Request descriptions.

<img align="right" src="https://user-images.githubusercontent.com/52587121/119507191-e6226c80-bd6e-11eb-8c2a-306309777e0f.png" hspace="20" width="150"/>