### PR TITLE
Fix merging time formats

### DIFF
--- a/src/main/java/org/embulk/util/guess/timeformat/GuessMatch.java
+++ b/src/main/java/org/embulk/util/guess/timeformat/GuessMatch.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.OptionalInt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class GuessMatch implements TimeFormatMatch {
     GuessMatch(
@@ -192,7 +194,13 @@ final class GuessMatch implements TimeFormatMatch {
         final List<GuessOption> anotherPartOptions = another.getPartOptions();
 
         for (int i = 0; i < this.partOptions.size(); i++) {
-            if (this.partOptions.get(i) == null) {
+            final GuessOption option = this.partOptions.get(i);
+            if (option == null || option == GuessOption.NIL) {
+                if (option == null) {
+                    logger.warn("GuessMatch.partOptions unexpectedly contains null instead of GuessOption.NIL.",
+                                new NullPointerException(
+                                        "GuessMatch.partOptions unexpectedly contains null instead of GuessOption.NIL."));
+                }
                 this.partOptions.set(i, anotherPartOptions.get(i));
             }
 
@@ -264,6 +272,8 @@ final class GuessMatch implements TimeFormatMatch {
         }
         return String.format("GuessMatch[%s]", builder.toString());
     }
+
+    private static final Logger logger = LoggerFactory.getLogger(GuessMatch.class);
 
     private static final List<GuessPart> DMY_SEQUENCE = Arrays.asList(GuessPart.DAY, GuessPart.MONTH, GuessPart.YEAR);
     private static final List<GuessPart> MDY_SEQUENCE = Arrays.asList(GuessPart.MONTH, GuessPart.DAY, GuessPart.YEAR);

--- a/src/test/java/org/embulk/util/guess/TestTimeFormatGuess.java
+++ b/src/test/java/org/embulk/util/guess/TestTimeFormatGuess.java
@@ -200,6 +200,16 @@ public class TestTimeFormatGuess {
         assertEquals("bar", TimeFormatGuess.mergeMostFrequentMatches(Arrays.asList(matches2)).getFormat());
     }
 
+    @Test
+    public void testMergeTimeFormat() {
+        assertGuess(
+                "%Y-%m-%d %k:%M:%S",
+                "2021-12-1 24:30:30",
+                "2021-12-1  4:30:30",
+                "2021-12-1 24:30:30",
+                "2021-12-1 24:30:30");
+    }
+
     private static class FakeMatch implements TimeFormatMatch {
         FakeMatch(final String format) {
             this.format = format;


### PR DESCRIPTION
We have sometimes observed that it sometimes mis-guesses `%H` and `%k`, compared to the original Ruby CSV guess. See the log of "`Guess with Embulk v0.10.28`" in https://github.com/embulk/embulk-guess-csv_verify/runs/3812611298 for example.

```
Error: -06 08:30:59.249 +0000 [ERROR] (0001:guess): [Embulk CSV guess verify] 'parser' has difference.
Error: -06 08:30:59.250 +0000 [ERROR] (0001:guess): [Embulk CSV guess verify] Java => {"charset":"UTF-8","newline":"LF","type":"csv","delimiter":",","quote":"\"","escape":"\"","trim_if_not_quoted":false,"skip_header_lines":1,"allow_extra_columns":false,"allow_optional_columns":false,"columns":[{"name":"v_long_max","type":"long"},{"name":"time","type":"timestamp","format":"%Y-%m-%d %H:%M:%S"},{"name":"foo","type":"string"},{"name":"","type":"long"}]}
Error: -06 08:30:59.251 +0000 [ERROR] (0001:guess): [Embulk CSV guess verify] Ruby => {"charset":"UTF-8","newline":"LF","type":"csv","delimiter":",","quote":"\"","escape":"\"","trim_if_not_quoted":false,"skip_header_lines":1,"allow_extra_columns":false,"allow_optional_columns":false,"columns":[{"name":"v_long_max","type":"long"},{"name":"time","type":"timestamp","format":"%Y-%m-%d %k:%M:%S"},{"name":"foo","type":"string"},{"name":"","type":"long"}]}
Error: -06 08:30:59.252 +0000 [ERROR] (0001:guess): [Embulk CSV guess verify] #<RuntimeError: embulk-guess-csv has difference between Java/Ruby.>
```

The difference has practically no problems by itself, but I looked into the details just in case it could have another hidden problem.

It turned out that the difference was caused by a bug in merging multiple guess results of time formats. This pull-request :
* 3f94f4cfc5ecc29495f04a83ae2c1bf262c3a94d: Adds a test for the case. (Tests fail.)
* e965f28f962940246341f87a379916ecc4f6eb48: Fixes it. (Tests succeed.)