### PR TITLE
Bump up to v0.2.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.embulk"
-version = "0.1.4-SNAPSHOT"
+version = "0.2.0-SNAPSHOT"
 description = "Guess helper for Embulk and Embulk plugins"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
Bumping up the version to v0.2.0 (not v0.1.5) because we have a bigger change in #24.