### PR TITLE
Fix guessing a timestamp format from null (Fix #25)

### DIFF
--- a/src/main/java/org/embulk/util/guess/SchemaGuess.java
+++ b/src/main/java/org/embulk/util/guess/SchemaGuess.java
@@ -304,7 +304,7 @@ public final class SchemaGuess {
         if (t.isTimestamp()) {
             final String format = this.timeFormatGuess.guess(
                     types.stream()
-                            .map(type -> type.isTimestamp() ? type.getFormatOrTimeValue() : null)
+                            .map(type -> (type != null && type.isTimestamp()) ? type.getFormatOrTimeValue() : null)
                             .filter(type -> type != null)
                             .collect(Collectors.toList()));
             return GuessedType.timestamp(format);

--- a/src/test/java/org/embulk/util/guess/TestSchemaGuess.java
+++ b/src/test/java/org/embulk/util/guess/TestSchemaGuess.java
@@ -148,6 +148,28 @@ public class TestSchemaGuess {
         assertEquals("long", guessed.get(0).get(String.class, "type"));
     }
 
+    @Test
+    public void testCoalesce5TimestampNullFormat() {
+        final LinkedHashMap<String, Object> record1 = new LinkedHashMap<>();
+        record1.put("a", "2016-01-01T12:34:56");
+        final LinkedHashMap<String, Object> record2 = new LinkedHashMap<>();
+        record2.put("a", null);
+        final LinkedHashMap<String, Object> record3 = new LinkedHashMap<>();
+        record3.put("a", "2016-03-04T12:34:56");
+        final ArrayList<LinkedHashMap<String, Object>> records = new ArrayList<>();
+        records.add(record1);
+        records.add(record2);
+        records.add(record3);
+
+        final List<ConfigDiff> guessed = fromLinkedHashMap(records);
+        assertEquals(1, guessed.size());
+        assertEquals("0", guessed.get(0).get(String.class, "index"));
+        assertEquals(0, guessed.get(0).get(int.class, "index"));
+        assertEquals("a", guessed.get(0).get(String.class, "name"));
+        assertEquals("timestamp", guessed.get(0).get(String.class, "type"));
+        assertEquals("%Y-%m-%dT%H:%M:%S", guessed.get(0).get(String.class, "format"));
+    }
+
     @ParameterizedTest
     @CsvSource({
             "true",


### PR DESCRIPTION
A bug. If the sample data includes `null` (not string-ish `"null"`), it threw `NullPointerException` although the exception is caught and ignored due to guess' mechanism. Fallen back to be guessed as `STRING`.

Looking in the original Ruby CSV guess, this bug looks to have been there. But let's fix this now.

* 9f994811ded65affb73a48c4c404cc8284d34e80: reproducing the issue in a test
* 28730b73458d8033cd56f9ccf86c6ba7c6960201: fixing it