### PR TITLE
Use Gradle's Java toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,6 @@ group = "org.embulk"
 version = "0.3.0-SNAPSHOT"
 description = "Guess helper for Embulk and Embulk plugins"
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 configurations {
     compileClasspath.resolutionStrategy.activateDependencyLocking()
     runtimeClasspath.resolutionStrategy.activateDependencyLocking()
@@ -28,6 +25,10 @@ tasks.withType(JavaCompile) {
 }
 
 java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+
     withJavadocJar()
     withSourcesJar()
 }


### PR DESCRIPTION
It enables the Java toolchain feature of Gradle to find JDK 8 automatically in builder's environment.
https://docs.gradle.org/current/userguide/toolchains.html